### PR TITLE
Bump Android CI ubuntu-24.04 to ARM public beta

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   build-android:
 
-    runs-on: ubuntu-24.04 # https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md
+    runs-on: ubuntu-24.04-arm # LTS Public Beta https://github.com/actions/partner-runner-images/blob/main/images/arm-ubuntu-24-image.md
 
     # Local job envs
 


### PR DESCRIPTION
Ref: https://github.com/leotm/react-native-template-new-architecture/issues/1818

Resolve: https://github.com/leotm/react-native-template-new-architecture/issues/1819

https://github.com/actions/partner-runner-images/blob/main/images/arm-ubuntu-24-image.md

> ## Omitted software
> 
> This section lists tools which are installed on [Ubuntu 24.04 X64 image](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md) provided by GitHub but omitted from the current image.
> 
> -  Tools that are not supported on Arm architecture
>     - Android SDK

```log
> SDK location not found. Define a valid SDK location with an ANDROID_HOME environment variable or by setting the sdk.dir path in your project's local properties file at '/home/runner/work/react-native-template-new-architecture/react-native-template-new-architecture/android/local.properties'.
```

manual https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#android setup required

e.g. https://github.com/react-native-community/docker-android/blob/main/Dockerfile
